### PR TITLE
Specify encoding and newline for note writing

### DIFF
--- a/distillate/obsidian.py
+++ b/distillate/obsidian.py
@@ -506,7 +506,7 @@ def create_paper_note(
                 content = content[:my_notes_idx]
 
             content = content.rstrip("\n") + marker_block
-            note_path.write_text(content)
+            note_path.write_text(content, encoding="utf-8", newline="\n")
             log.info("Merged note: %s", note_path)
             return note_path
 


### PR DESCRIPTION
On Windows, writing Obsidian notes without specifying encoding can fail (and did for me). Update note writing to specify UTF-8 encoding and newline.